### PR TITLE
Clarify an important step in the publishing process

### DIFF
--- a/publishing/publish-game.md
+++ b/publishing/publish-game.md
@@ -15,7 +15,7 @@ First you will need to register your game:
 ### Publish game
 
 {% hint style="warning" %}
-**Before you publish for the first time, make you you have done the following steps:**
+**Before you publish for the first time, make sure you have done the following steps:**
 
 1. Open Unity Hub and select the Installations tab
 2. Press Manage on the installation you have been using for Airship

--- a/publishing/publish-game.md
+++ b/publishing/publish-game.md
@@ -1,7 +1,5 @@
 # Publish Game
 
-
-
 {% hint style="warning" %}
 Simplified publishing only works when signed in with Google. If you don't sign in with Google you can [publish using an API key](https://app.gitbook.com/o/Ob5dDteJHkKChzdNkVaS/s/IbaXflSJA8L9N9yOx089/~/changes/322/other/publishing-with-key).
 {% endhint %}
@@ -16,14 +14,25 @@ First you will need to register your game:
 
 ### Publish game
 
+{% hint style="warning" %}
+**Before you publish for the first time, make you you have done the following steps:**
+
+1. Open Unity Hub and select the Installations tab
+2. Press Manage on the installation you have been using for Airship
+3. Click on Add Modules and select **Mac Build Support (Mono)**
+4. Install the module, restart Unity Editor, and Publish your game!
+
+This process is essential to publishing your game to all platforms.
+{% endhint %}
+
 Once you have created a game you can publish to it from the Unity Editor:
 
 1.  At the top of your editor click the profile picture and sign in\
-    &#x20;
+
 
     <figure><img src="../.gitbook/assets/Screenshot 2024-09-13 at 5.21.11 PM.png" alt="" width="375"><figcaption></figcaption></figure>
 2.  Once you are signed in click the settings button\
-    &#x20;
+
 
     <figure><img src="../.gitbook/assets/Screenshot 2024-09-13 at 5.26.58 PM.png" alt=""><figcaption></figcaption></figure>
 3. Open the Publish Target dropdown and select your game


### PR DESCRIPTION
Lets the user know that **Mac Build Support** needs to be installed for the engine to build the game files and publish.

_Sorry for my first pull request on this subject, I got GitBook's web editor working for this one._