### PR TITLE
Changed text in Mono/IL2CPP in Windows / Mac Build Support

### DIFF
--- a/getting-started/installing-airship.md
+++ b/getting-started/installing-airship.md
@@ -30,8 +30,8 @@ This project has everything prepared to start building a game on Airship.&#x20;
     * Android Build Support
     * iOS Build Support
     * Linux Build Support (IL2CPP)
-    * Windows Build Support (IL2CPP)
-    * Mac Build Support (Mono)
+    * Windows Build Support (Mono)
+    * Mac Build Support (IL2CPP)
 
 <div align="left"><figure><img src="../.gitbook/assets/image (3) (2).png" alt="" width="375"><figcaption></figcaption></figure></div>
 

--- a/publishing/publish-game.md
+++ b/publishing/publish-game.md
@@ -43,8 +43,8 @@ Your first publish might take a few minutes. Future publishes will be faster.
    * Android Build Support
    * iOS Build Support
    * Linux Build Support (IL2CPP)
-   * Windows Build Support (IL2CPP)
-   * Mac Build Support (Mono)
+   * Windows Build Support (Mono)
+   * Mac Build Support (IL2CPP)
 4. Install the module, restart Unity Editor, and Publish your game!
 {% endhint %}
 


### PR DESCRIPTION
I'm just a random guy who found out about Airship and now wants to try to make a game in Airship. While following your documentation, I found and issue where Windows Build Support doesn't have IL2CPP and Mac Build Support doesn't have Mono. It basically doesn't show that in the install unity page. I assume this wouldn't change much, as they both build to a valid binary at the end anyways, but this change can clear up further confusion.

Ignore the badly named title. Also if I'm wrong, just close the pr ig